### PR TITLE
Fixed argument of denops#server#connect()

### DIFF
--- a/autoload/denops_shared_server.vim
+++ b/autoload/denops_shared_server.vim
@@ -23,7 +23,7 @@ function! denops_shared_server#install() abort
   call denops#util#info('wait 1 second for the shared server startup...')
   sleep 1
   call denops#util#info('connect to the shared server')
-  call denops#server#connect()
+  call denops#server#connect(g:denops_server_addr)
   call denops#util#info('stop the local server')
   call denops#server#stop()
 endfunction


### PR DESCRIPTION
Before PR, getting the below error.
```
E119: Not enough arguments for function: denops#server#connect
```