### PR TITLE
Revert arguments of denops#server#connect()

### DIFF
--- a/autoload/denops_shared_server.vim
+++ b/autoload/denops_shared_server.vim
@@ -23,7 +23,7 @@ function! denops_shared_server#install() abort
   call denops#util#info('wait 5 second for the shared server startup...')
   sleep 5
   call denops#util#info('connect to the shared server')
-  call denops#server#connect(g:denops_server_addr)
+  call denops#server#connect()
   call denops#util#info('stop the local server')
   call denops#server#stop()
 endfunction


### PR DESCRIPTION
Revert #3
I was confused which one is the latest specification.

https://github.com/vim-denops/denops.vim/blob/53ce6187e04da044c85b79ef856f1487326a7ac5/autoload/denops/server.vim#L11

Is this okay?