### PR TITLE
fix: support Denops.vim v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # 🎃 denops-shared-server
 
-This is a helper Vim plugin to install/uninstall [denops.vim][]'s shared server.
+[![Denops.vim 7.0.0 or above]][Denops.vim-v7.0.0]
 
-[denops.vim]: https://github.com/vim-denops/denops.vim
+This is a helper Vim plugin to install/uninstall [Denops.vim][]'s shared server.
+
+[Denops.vim]: https://github.com/vim-denops/denops.vim
+[Denops.vim-v7.0.0]: https://github.com/vim-denops/denops.vim/releases/tag/v7.0.0
+[Denops.vim 7.0.0 or above]: https://img.shields.io/badge/Denops.vim-Support%207.0.0-yellowgreen.svg
 
 ## Usage
 

--- a/autoload/denops_shared_server.vim
+++ b/autoload/denops_shared_server.vim
@@ -17,10 +17,14 @@ function! denops_shared_server#install() abort
   call denops_shared_server#{command}#install(options)
   call denops_shared_server#util#info('wait 5 second for the shared server startup...')
   sleep 5
+  if denops#server#status() !=# "stopped"
+    augroup denops_shared_server_install
+      autocmd!
+      autocmd User DenopsClosed ++once ++nested call s:stop_local_server()
+    augroup END
+  endif
   call denops_shared_server#util#info('connect to the shared server')
-  call denops#server#connect()
-  call denops_shared_server#util#info('stop the local server')
-  call denops#server#stop()
+  call denops#server#reconnect()
 endfunction
 
 function! denops_shared_server#uninstall() abort
@@ -69,4 +73,9 @@ function! s:detect_command() abort
     return ''
   endif
   return s:command
+endfunction
+
+function! s:stop_local_server() abort
+  call denops_shared_server#util#info('stop the local server')
+  call denops#server#stop()
 endfunction


### PR DESCRIPTION
The behavior of `denops#server#*` has changed in v7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced server management for the Denops plugin, ensuring proper lifecycle control when the environment is closed.
	- Improved connection logic with robust reconnection capabilities.

- **Documentation**
	- Updated README.md with clearer content and formatting, including a compatibility badge for Denops.vim version 7.0.0 and above.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->